### PR TITLE
Add reference to the Terragrunt presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This is a repository that holds the demos for 3 short (~1 hr each) training sessions:
 1. [Introduction to Terraform](https://docs.google.com/presentation/d/1V1aQdGOk_IYJwRi8VJmMDs0wc5kwpvhwgDjgTEqWu7c/edit?usp=sharing)
 2. [Terraform modules](https://docs.google.com/presentation/d/1Sj97HL6RHK--WSPnWjGZxrYYevo4TgWCfLIzECOVR1E/edit?usp=sharing)
-3. Terragrunt
+3. [Terragrunt Introduction](https://docs.google.com/presentation/d/1kGPBi4pmr4icDIK3rUcDNM6_GF0Dvgt1q7d9JF4WEbc/edit?usp=sharing)


### PR DESCRIPTION
Add the link to the presentation for the session 3: Terragrunt Introduction.