### PR TITLE
Reference TF modules from main branch

### DIFF
--- a/3-terragrunt/test/compute-plane/terragrunt.hcl
+++ b/3-terragrunt/test/compute-plane/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=master"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=main"
 }
 
 dependency control-plane {

--- a/3-terragrunt/test/compute-plane/terragrunt.hcl
+++ b/3-terragrunt/test/compute-plane/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=feature/add-terragrunt-session"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=master"
 }
 
 dependency control-plane {

--- a/3-terragrunt/test/connectivity/terragrunt.hcl
+++ b/3-terragrunt/test/connectivity/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/network-module?ref=feature/add-terragrunt-session"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/network-module?ref=master"
 }
 
 dependency resource-group {

--- a/3-terragrunt/test/connectivity/terragrunt.hcl
+++ b/3-terragrunt/test/connectivity/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/network-module?ref=master"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/network-module?ref=main"
 }
 
 dependency resource-group {

--- a/3-terragrunt/test/control-plane/terragrunt.hcl
+++ b/3-terragrunt/test/control-plane/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=master"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=main"
 }
 
 dependency connectivity {

--- a/3-terragrunt/test/control-plane/terragrunt.hcl
+++ b/3-terragrunt/test/control-plane/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=feature/add-terragrunt-session"
+  source = "git::https://github.com/bernardhalas/terraform-trainings.git//2-modules/vm-module?ref=master"
 }
 
 dependency connectivity {


### PR DESCRIPTION
Use the references to the modules from the `main` branch of the repository.